### PR TITLE
feat: new logic for malloc caller detection

### DIFF
--- a/malloc_tester.c
+++ b/malloc_tester.c
@@ -17,14 +17,17 @@
  * Ensure the target program is compiled with debugging and symbol info:
  *     -rdynamic -g
  *
- * Compile malloc tester:
+ * If you are lazy (and you should be) use the script
+ *     ./run_tester.sh target_program [args]
+ *
+ * Compile the tester:
  *     gcc -fPIC -shared -o malloc_tester.so malloc_tester.c -ldl -g
  *
- * Run the target binary with injection:
- *     LD_PRELOAD=./malloc_tester.so ./your_program
+ * Run the tester:
+ *     LD_PRELOAD=./malloc_tester.so ./target_program
  *
  * Run in GDB:
- *     LD_PRELOAD=./malloc_tester.so gdb ./your_program
+ *     LD_PRELOAD=./malloc_tester.so gdb ./target_program
  *
  * Configuration can be modified live during GDB execution:
  *     set malloc_cfg.max_calls = <int>

--- a/run_tester.sh
+++ b/run_tester.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Check if target program is provided
+if [ -z "$1" ]; then
+	echo "Usage: $0 <target_program> [args...]"
+	exit 1
+fi
+
+echo "Warning: make sure the targeted project is compiled with -rdynamic -g"
+
+# Build the malloc tester
+echo "[script] Compiling malloc_tester.so..."
+gcc -fPIC -shared -o malloc_tester.so malloc_tester.c -ldl -g
+
+# Run the target program with LD_PRELOAD
+echo "[script] Running malloc tester with $1"
+LD_PRELOAD=./malloc_tester.so "$@"


### PR DESCRIPTION
1. j'ai trouve la fonction dladdr qui donne des infos tres precise sur quel executable appelle la fonction en cours et je me suis servi de ca pour distinguer le user code et les librairies partagees

2. En compilant le projet a tester avec les bons flags j'ai trouve un moyen de recuperer le nom de la fonction qui appelle malloc, a partir de ca je peux faire "ignore toutes les fonctions qui contiennent mlx" par exemple

Si tu peux tester ca et me dire ce que tu en penses ca me ferait super plaisir !

Merci pour ton aide !